### PR TITLE
Add missing "run" to invoke command line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
             at: .
         - restore_cache:
             key: node-cache-v2{{ checksum "package.json" }}
-        - git clone git@github.com:Rise-Vision/private-keys.git
-        - cp ./private-keys/twitter/twitter-app-credentials.js ./src
+        - run: git clone git@github.com:Rise-Vision/private-keys.git
+        - run: cp ./private-keys/twitter/twitter-app-credentials.js ./src
         - run: npm run build
         - save_cache:
             key: node-cache-v2{{ checksum "package.json" }}


### PR DESCRIPTION
As per builds [34](https://circleci.com/gh/Rise-Vision/twitter-module/34) and [26](https://circleci.com/gh/Rise-Vision/twitter-module/26). Noticed we are missing "run". 