### PR TITLE
Fix/remove external logging for invalid content files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2793,6 +2793,28 @@
         "readable-stream": "2.3.5"
       }
     },
+    "fs-extra": {
+      "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
+      "requires": {
+        "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+        },
+        "rimraf": {
+          "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+          }
+        }
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -4879,31 +4901,6 @@
             "ms": "2.0.0"
           }
         },
-        "fs-extra": {
-          "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
-              "dev": true,
-              "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-          "dev": true
-        },
         "rise-common-electron": {
           "version": "git://github.com/Rise-Vision/rise-common-electron.git#467d4c639ee1826961b5f7717f463ce9bd324b23",
           "dev": true,
@@ -4932,10 +4929,6 @@
               }
             }
           }
-        },
-        "windows-shortcuts": {
-          "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b",
-          "dev": true
         }
       }
     },
@@ -6453,28 +6446,6 @@
             "ms": "2.0.0"
           }
         },
-        "fs-extra": {
-          "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
-          "requires": {
-            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
-              "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-        },
         "https-proxy-agent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
@@ -6484,9 +6455,6 @@
             "debug": "2.6.9",
             "extend": "3.0.1"
           }
-        },
-        "windows-shortcuts": {
-          "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b"
         }
       }
     },
@@ -7951,6 +7919,9 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
+    },
+    "windows-shortcuts": {
+      "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b"
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/test/unit/messaging/watch/watch.js
+++ b/test/unit/messaging/watch/watch.js
@@ -16,6 +16,7 @@ describe("Messaging -> Watch - Unit", ()=> {
     const settings = {displayid: "DIS123"};
 
     simple.mock(commonMessaging, "broadcastMessage").returnWith();
+    simple.mock(logger, "file").returnWith();
     simple.mock(logger, "error").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
   });
@@ -175,7 +176,7 @@ describe("Messaging -> Watch - Unit", ()=> {
     });
   });
 
-  it("should catch invalid company id", ()=>{
+  it("should catch invalid content file - no companyId", ()=>{
     const mockScheduleText = '{"content": {"schedule": {}}}';
     simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
 
@@ -185,12 +186,42 @@ describe("Messaging -> Watch - Unit", ()=> {
       ospath: "xxxxxxx"
     })
     .then(() => {
-      assert(logger.error.lastCall.args[0].includes("Invalid CompanyId"));
-      assert(logger.error.lastCall.args[1].startsWith("Could not parse"));
+      assert(logger.file.lastCall.args[0].includes("invalid content file - no companyId in content file"));
+      assert.equal(logger.error.callCount, 0);
+    });
+  });
+
+  it("should catch invalid content file - no schedule", ()=>{
+    const mockScheduleText = '{"content": {"presentations": {}}}';
+    simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
+
+    return watch.receiveContentFile({
+      topic: "file-update",
+      status: "CURRENT",
+      ospath: "xxxxxxx"
+    })
+    .then(() => {
+      assert(logger.file.lastCall.args[0].includes("invalid content file - no companyId in content file"));
+      assert.equal(logger.error.callCount, 0);
     });
   });
 
   it("should catch invalid content file", ()=>{
+    const mockScheduleText = '{}';
+    simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
+
+    return watch.receiveContentFile({
+      topic: "file-update",
+      status: "CURRENT",
+      ospath: "xxxxxxx"
+    })
+    .then(() => {
+      assert(logger.file.lastCall.args[0].includes("invalid content file - no companyId in content file"));
+      assert.equal(logger.error.callCount, 0);
+    });
+  });
+
+  it("should catch invalid content file - can not parse", ()=>{
     const mockScheduleText = '{"content": invalid}';
     simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
 
@@ -204,7 +235,7 @@ describe("Messaging -> Watch - Unit", ()=> {
     });
   });
 
-  it("should catch invalid content file", ()=>{
+  it("should catch invalid content file - can not parse", ()=>{
     const mockScheduleText = '{{';
     simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
 


### PR DESCRIPTION
The errors were being reported for cases where displays don't have any schedules assigned to them but were kicking off Twitter Module as part of player. I've changed these to file logs now and added tests.