### PR TITLE
"no credentials" error log during startup

### DIFF
--- a/src/components/components-controller.js
+++ b/src/components/components-controller.js
@@ -2,6 +2,7 @@ const components = require("./components");
 const logger = require("../../src/logger");
 const twitter = require("../../src/api/twitter");
 const broadcastIPC = require("../../src/messaging/broadcast-ipc");
+const watch = require("../messaging/watch/watch");
 
 function formatTweets(tweets) {
   return new Promise(res => {
@@ -35,7 +36,10 @@ function updateComponent(componentId, componentData) {
   }
   twitter.init();
   if (!twitter.credentialsExist()) {
-    return logger.error("Credentials do not exist - can not update components");
+    if (watch.isWatchMessagesAlreadySentForCredentials()) {
+      return logger.error("Credentials do not exist - can not update components");
+    }
+    return logger.all("info", "Watch message for credentials was not send yet - can not update components");
   }
 
   twitter.getUserTweets(componentId, data.screen_name, (error, tweets)=>{
@@ -51,7 +55,10 @@ function updateAllComponents() {
   logger.file(`Updating all components - re-fetching tweets and restarting streams`);
   twitter.init();
   if (!twitter.credentialsExist()) {
-    return logger.error("Credentials do not exist - can not update components");
+    if (watch.isWatchMessagesAlreadySentForCredentials()) {
+      return logger.error("Credentials do not exist - can not update components");
+    }
+    return logger.all("info", "Watch message for credentials was not send yet - can not update components");
   }
 
   twitter.finishAllRefreshes();

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -12,6 +12,10 @@ function clearMessagesAlreadySentFlagForCredentials() {
   watchMessagesAlreadySentForCredentials = false;
 }
 
+function isWatchMessagesAlreadySentForCredentials() {
+  return watchMessagesAlreadySentForCredentials;
+}
+
 function sendWatchMessagesForCredentials() {
   if (!watchMessagesAlreadySentForCredentials) {
     const filePath = `risevision-company-notifications/${config.getCompanyId()}/credentials/twitter.json`;
@@ -71,5 +75,6 @@ function receiveCredentialsFile(message) {
 module.exports = {
   clearMessagesAlreadySentFlagForCredentials,
   receiveCredentialsFile,
-  sendWatchMessagesForCredentials
+  sendWatchMessagesForCredentials,
+  isWatchMessagesAlreadySentForCredentials
 };

--- a/test/integration/messaging/messaging.js
+++ b/test/integration/messaging/messaging.js
@@ -109,6 +109,7 @@ describe("Messaging - Integration", function() {
 
     it("does not update twitter component if credentials do not exist", () => {
       mock(twitter, "credentialsExist").returnWith(false);
+      mock(watch, "isWatchMessagesAlreadySentForCredentials").returnWith(true);
 
       return new Promise(res => {
         commonMessaging.broadcastMessage({
@@ -169,6 +170,7 @@ describe("Messaging - Integration", function() {
     it("does not update twitter components if credentials JSON file is deleted or does not exist", () => {
       mock(watch, "receiveCredentialsFile").returnWith(Promise.resolve());
       mock(twitter, "credentialsExist").returnWith(false);
+      mock(watch, "isWatchMessagesAlreadySentForCredentials").returnWith(true);
       mock(components, "getComponents").returnWith({"risevision": {"screen_name": "risevision", "hashtag": "testtag"}});
 
       return new Promise(res => {


### PR DESCRIPTION
Only send error if the twitter module is already watching for credentials.
Otherwise it's just a `info` log.
@Rise-Vision/content please review