### PR TITLE
Improves error logging by adding more details

### DIFF
--- a/src/components/components-controller.js
+++ b/src/components/components-controller.js
@@ -58,7 +58,7 @@ function updateAllComponents() {
     if (watch.isWatchMessagesAlreadySentForCredentials()) {
       return logger.error("Credentials do not exist - can not update components");
     }
-    return logger.all("info", "Watch message for credentials was not send yet - can not update components");
+    return logger.all("info", "Watch message for credentials was not sent yet - can not update components");
   }
 
   twitter.finishAllRefreshes();

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -33,10 +33,12 @@ function sendWatchMessagesForCredentials() {
 function loadCurrentCredentials(credentialsPath) {
   if (credentialsPath && platform.fileExists(credentialsPath)) {
     logger.debug(`reading ${credentialsPath}`);
+    let retrievedData = null;
 
     return platform.readTextFile(credentialsPath)
     .then(data =>
     {
+      retrievedData = data;
       const credentials = JSON.parse(data);
 
       if (!Reflect.has(credentials, "oauth_token") || !Reflect.has(credentials, "oauth_token_secret")) {
@@ -50,7 +52,7 @@ function loadCurrentCredentials(credentialsPath) {
 
     })
     .catch(error =>
-      logger.error(error.message, `Could not parse credentials file ${credentialsPath}`)
+      logger.error(error.message, `Could not parse credentials file ${credentialsPath} - ${retrievedData}`)
     );
   }
 

--- a/test/unit/components/components-controller.js
+++ b/test/unit/components/components-controller.js
@@ -98,7 +98,7 @@ describe("Components-Controller - Unit", ()=>
     mock(watch, "isWatchMessagesAlreadySentForCredentials").returnWith(false);
     componentsController.updateAllComponents();
     assert(logger.all.lastCall.args[0].includes("info"));
-    assert(logger.all.lastCall.args[1].includes("Watch message for credentials was not send yet"));
+    assert(logger.all.lastCall.args[1].includes("Watch message for credentials was not sent yet"));
     assert(!twitter.finishAllRefreshes.called);
     done();
   });


### PR DESCRIPTION
covers case where we get "could not parse credentials" error meaning that the credentials file is likely nonexistent or oddly formatted. it's quite difficult to know currently what's happening in this specific case without looking at these displays directly.