### PR TITLE
Fix/fixes issue 60

### DIFF
--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -19,8 +19,9 @@ module.exports = {
       components.addComponent(message.data.component_id, Object.assign({}, {screen_name, hashtag}));
       componentsController.updateComponent(message.data.component_id);
 
-      // The watch was removed because twitter.json was DELETED or NOEXIST;
-      // so we create the watch again to see if it's back.
+      // The watch was removed because twitter.json was DELETED or NOEXIST,
+      // and thus the ready status was changed from null to false;
+      // so we send the WATCH message again to see if the file is back.
       if (config.getReadyStatus() === false && watch.isWatchMessagesAlreadySentForCredentials()) {
         watch.clearMessagesAlreadySentFlagForCredentials();
         watch.sendWatchMessagesForCredentials();

--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -4,6 +4,7 @@ const components = require("../../../src/components/components");
 const componentsController = require("../../../src/components/components-controller");
 const entry = require("./entry");
 const logger = require("../../../src/logger");
+const watch = require("../watch/watch");
 
 module.exports = {
   process(message) {
@@ -17,6 +18,13 @@ module.exports = {
 
       components.addComponent(message.data.component_id, Object.assign({}, {screen_name, hashtag}));
       componentsController.updateComponent(message.data.component_id);
+
+      // The watch was removed because twitter.json was DELETED or NOEXIST;
+      // so we create the watch again to see if it's back.
+      if (config.getReadyStatus() === false && watch.isWatchMessagesAlreadySentForCredentials()) {
+        watch.clearMessagesAlreadySentFlagForCredentials();
+        watch.sendWatchMessagesForCredentials();
+      }
     } catch (error) {
       logger.file(`TWITTER-WATCH - UPDATE error in ${config.moduleName} module: ${error}`);
     }

--- a/test/unit/messaging/update/update.js
+++ b/test/unit/messaging/update/update.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const components = require("../../../../src/components/components");
+const componentsController = require("../../../../src/components/components-controller");
+const config = require("../../../../src/config/config");
+const logger = require("../../../../src/logger");
+const update = require("../../../../src/messaging/update/update");
+const watch = require("../../../../src/messaging/watch/watch");
+
+describe("Messaging -> Update Component - Unit", () => {
+  beforeEach(()=>{
+    simple.mock(logger, "file").returnWith();
+    simple.mock(components, "addComponent").returnWith();
+    simple.mock(componentsController, "updateComponent").returnWith();
+    simple.mock(watch, "sendWatchMessagesForCredentials").returnWith();
+    simple.mock(watch, "isWatchMessagesAlreadySentForCredentials").returnWith(true);
+  });
+
+  afterEach(() => simple.restore());
+
+  it("should send watch message for credentials again if twitter.json was deleted or not existent", () => {
+    simple.mock(config, "getReadyStatus").returnWith(false);
+
+    update.process({data: {"component_id": "x", "screen_name": "y"}});
+
+    assert(watch.sendWatchMessagesForCredentials.called);
+  });
+
+  it("should not send watch message for credentials again if we still don't have status for twitter.json", () => {
+    simple.mock(config, "getReadyStatus").returnWith(null);
+
+    update.process({data: {"component_id": "x", "screen_name": "y"}});
+
+    assert(!watch.sendWatchMessagesForCredentials.called);
+  });
+
+  it("should not send watch message for credentials again if twitter.json exists", () => {
+    simple.mock(config, "getReadyStatus").returnWith(true);
+
+    update.process({data: {"component_id": "x", "screen_name": "y"}});
+
+    assert(!watch.sendWatchMessagesForCredentials.called);
+  });
+});


### PR DESCRIPTION
This is the proposed fix for the issue.

The issue happens because when the twitter.json is deleted or does not exist, local storage removes it from the watch list. But if it's added or re-added later via the widget settings the module won't find out until is restarted.

In this case we are leveraging the TWITTER-WATCH that is naturally called after the presentation is published again, and in case the file was previously found to be non-existent after a previous watch was already sent, we send the watch again to see if it's now present again.

I tested this manually using an staged version, and the widget now switches OK between mocked tweets and actual tweets.
