### PR TITLE
Fix/Fixes issue #60

### DIFF
--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -16,8 +16,7 @@ function handleStatusRequest() {
   // The watch was removed because twitter.json was DELETED or NOEXIST,
   // and thus the ready status was changed from null to false;
   // so we send the WATCH message again to see if the file is back.
-  if (config.getReadyStatus() === false && watch.isWatchMessagesAlreadySentForCredentials()) {
-    watch.clearMessagesAlreadySentFlagForCredentials();
+  if (config.getReadyStatus() === false) {
     watch.sendWatchMessagesForCredentials();
   }
 }

--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -11,7 +11,15 @@ const status = require("./status/status");
 let initialRequestAlreadySent = false;
 
 function handleStatusRequest() {
-  return status.sendStatusMessage();
+  status.sendStatusMessage();
+
+  // The watch was removed because twitter.json was DELETED or NOEXIST,
+  // and thus the ready status was changed from null to false;
+  // so we send the WATCH message again to see if the file is back.
+  if (config.getReadyStatus() === false && watch.isWatchMessagesAlreadySentForCredentials()) {
+    watch.clearMessagesAlreadySentFlagForCredentials();
+    watch.sendWatchMessagesForCredentials();
+  }
 }
 
 function handleComponent(message) {

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -74,6 +74,10 @@ function receiveCredentialsFile(message) {
       config.setTwitterCredentials(null);
       twitterWrapper.createClient();
       status.updateReadyStatus(false);
+
+      // so the WATCH message can be sent again if credentials are added again later
+      clearMessagesAlreadySentFlagForCredentials();
+
       // allows linking in tests.
       return Promise.resolve();
 

--- a/test/unit/messaging/messaging.js
+++ b/test/unit/messaging/messaging.js
@@ -1,0 +1,60 @@
+/* eslint-env mocha */
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const commonMessaging = require("common-display-module/messaging");
+const config = require("../../../src/config/config");
+const logger = require("../../../src/logger");
+const messaging = require("../../../src/messaging/messaging");
+const status = require("../../../src/messaging/status/status");
+const watch = require("../../../src/messaging/watch/watch");
+
+describe("Messaging -> Messaging", () => {
+  beforeEach(() => {
+    simple.mock(logger, "file").returnWith();
+    simple.mock(status, "sendStatusMessage").returnWith();
+    simple.mock(watch, "sendWatchMessagesForCredentials").returnWith();
+    simple.mock(watch, "isWatchMessagesAlreadySentForCredentials").returnWith(true);
+
+    simple.mock(commonMessaging, "receiveMessages").resolveWith({
+      on: (type, handler) => {
+        assert.equal(type, "message");
+
+        handler({topic: 'TWITTER-STATUS-REQUEST'});
+      }
+    });
+  });
+
+  afterEach(() => simple.restore());
+
+  it("should send watch message for credentials again if twitter.json was deleted or not existent", () => {
+    simple.mock(config, "getReadyStatus").returnWith(false);
+
+    return messaging.init()
+    .then(() => {
+      assert(status.sendStatusMessage.called);
+      assert(watch.sendWatchMessagesForCredentials.called);
+    });
+  });
+
+  it("should not send watch message for credentials again if we still don't have status for twitter.json", () => {
+    simple.mock(config, "getReadyStatus").returnWith(null);
+
+    return messaging.init()
+    .then(() => {
+      assert(status.sendStatusMessage.called);
+      assert(!watch.sendWatchMessagesForCredentials.called);
+    });
+  });
+
+  it("should not send watch message for credentials again if twitter.json exists", () => {
+    simple.mock(config, "getReadyStatus").returnWith(true);
+
+    return messaging.init()
+    .then(() => {
+      assert(status.sendStatusMessage.called);
+      assert(!watch.sendWatchMessagesForCredentials.called);
+    });
+  });
+
+});


### PR DESCRIPTION
Fix for the issue using TWITTER-STATUS-REQUEST.

The issue happens because when the twitter.json is deleted or does not exist, local storage removes it from the watch list. But if it's added or re-added later via the widget settings the module won't find out until is restarted.

In this case we are leveraging the TWITTER-STATUS-REQUEST that is naturally called after the presentation is published again, and in case the file was previously found to be non-existent after a previous WATCH was already sent, we send the WATCH again to see if the file is present again.

I tested this manually using an staged version, and the widget now switches OK between mocked tweets and actual tweets.