### PR TITLE
Chore/Remove credentials path in error message

### DIFF
--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -58,7 +58,7 @@ function loadCurrentCredentials(credentialsPath) {
     .catch(error =>
     {
       status.updateReadyStatus(false);
-      logger.error(error.message, `Could not parse credentials file ${credentialsPath} - ${retrievedData}`);
+      logger.error(error.message, `Could not parse credentials file - ${retrievedData}`);
     });
   }
 


### PR DESCRIPTION
- Including the credentials path is unnecessary for the sake of debugging and it is causing us to hit the max length of 128 characters for entries. 
- We really only need the retrieved data as part of the log. 
- This is a minor change that should be deployed tomorrow. 