### PR TITLE
Fix/issue 62 log error

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/src/components/components-controller.js
+++ b/src/components/components-controller.js
@@ -44,7 +44,8 @@ function updateComponent(componentId, componentData) {
 
   twitter.getUserTweets(componentId, data.screen_name, (error, tweets)=>{
     if (error) {
-      logger.error(`Could not get tweets for ${
+      // log as warning because the problem could be that an invalid Twitter username was set.
+      logger.all('warning', `Could not get tweets for ${
         JSON.stringify(data)
       }, error: ${
         JSON.stringify(error)

--- a/src/components/components-controller.js
+++ b/src/components/components-controller.js
@@ -44,7 +44,7 @@ function updateComponent(componentId, componentData) {
 
   twitter.getUserTweets(componentId, data.screen_name, (error, tweets)=>{
     if (error) {
-      // log as warning because the problem could be that an invalid Twitter username was set.
+      // log as warning because the problem could be that an non-existent Twitter screen name was set by the user.
       logger.all('warning', `Could not get tweets for ${
         JSON.stringify(data)
       }, error: ${

--- a/src/components/components-controller.js
+++ b/src/components/components-controller.js
@@ -44,7 +44,11 @@ function updateComponent(componentId, componentData) {
 
   twitter.getUserTweets(componentId, data.screen_name, (error, tweets)=>{
     if (error) {
-      logger.file(`Could get tweets for ${JSON.stringify(data)}`);
+      logger.error(`Could not get tweets for ${
+        JSON.stringify(data)
+      }, error: ${
+        JSON.stringify(error)
+      }`);
     } else {
       sendUpdateMessage("Current", tweets, componentId, data);
     }


### PR DESCRIPTION
## Description
Log error detail when twitter data retrieval fails.

## Motivation and Context
The problem the user in issue 62 was facing could not be determined because there wasn't enough information in the log ( and also the log message indicating the problem was misleading )
https://github.com/Rise-Vision/rise-twitter/issues/62

So we are now adding the error detail to the error message.

## How Has This Been Tested?
A staged version of the module was created here:
https://console.cloud.google.com/storage/browser/install-versions.risevision.com/staging/twitter/2019.09.25.19.32/?project=avid-life-623

and a schedule was defined pointing to a presentation with a Twitter widget pointing to a non-existent screen name:
https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

and I confirmed the error logs now include the error:
```
2019/09/25 14:58:16 - warning
Could not get tweets for {"screen_name":"unachuecasuperacura","hashtag":null}, error: [{"code":34,"message":"Sorry, that page does not exist."}]
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - Manual tests completed.
     - It will wait for priority electron upgrades to finish, and will follow standard player release.
     - Support will be notified in relationship to issue 62 once this is released.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need for automated testing, documentation updates.